### PR TITLE
refactor: Rename URL query parameters in the medical device app

### DIFF
--- a/apps/medical_device/serializers.py
+++ b/apps/medical_device/serializers.py
@@ -1,14 +1,14 @@
 from rest_framework import serializers
 
 class ManufacturerApiParamsSerializer(serializers.Serializer):
-    Entrps = serializers.CharField(required=False)
-    Induty_type = serializers.CharField(required=False)
-    Prmisn_dt = serializers.CharField(required=False)
-    pageNo = serializers.IntegerField(required=False)
-    numOfRows = serializers.IntegerField(required=False)
-    Meddev_entp_no = serializers.CharField(required=False)
+    page = serializers.IntegerField(required=False, source='pageNo')
+    per_page = serializers.IntegerField(required=False, source='numOfRows')
+    company_name = serializers.CharField(required=False, source='Entrps')
+    industry_type = serializers.CharField(required=False, source='Induty_type')
+    permit_date = serializers.CharField(required=False, source='Prmisn_dt')
+    license_number = serializers.CharField(required=False, source='Meddev_entp_no')
 
-class ProductApiParamsSerializer(serializers.Serializer):
-    pageNo = serializers.IntegerField(required=False)
-    numOfRows = serializers.IntegerField(required=False)
-    PRDLST_NM = serializers.CharField(required=False)
+class ProductListApiParamsSerializer(serializers.Serializer):
+    page = serializers.IntegerField(required=False, source='pageNo')
+    per_page = serializers.IntegerField(required=False, source='numOfRows')
+    item_name = serializers.CharField(required=False, source='PRDLST_NM')


### PR DESCRIPTION
close #13

- Improve clarity by renaming URL query parameters in the medical device app to snake_case